### PR TITLE
Feature/cleanup job

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 name = "grpc_banking_transactions_notifications"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+default-run = "grpc_banking_transactions_notifications"
 
 [dependencies]
 solana-sdk = "~1.16.17"

--- a/src/bin/cleanupdb.rs
+++ b/src/bin/cleanupdb.rs
@@ -1,12 +1,28 @@
+use clap::Parser;
 use grpc_banking_transactions_notifications::postgres;
 use grpc_banking_transactions_notifications::postgres::PostgresSession;
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+
+    #[arg(short, long, help = "num of slots to keep relative to highest slot in blocks table")]
+    pub num_slots_to_keep: i64,
+
+    #[arg(short, long, default_value_t = false)]
+    pub dry_run: bool,
+}
 
 #[tokio::main()]
 async fn main() {
     tracing_subscriber::fmt::init();
 
+    let Args {
+        num_slots_to_keep, dry_run
+    } = Args::parse();
+
     let session = PostgresSession::new().await.unwrap();
 
-    session.cleanup_old_data(true).await;
+    session.cleanup_old_data(num_slots_to_keep, dry_run).await;
 
 }

--- a/src/bin/cleanupdb.rs
+++ b/src/bin/cleanupdb.rs
@@ -1,0 +1,12 @@
+use grpc_banking_transactions_notifications::postgres;
+use grpc_banking_transactions_notifications::postgres::PostgresSession;
+
+#[tokio::main()]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let session = PostgresSession::new().await.unwrap();
+
+    session.cleanup_old_data(true).await;
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod postgres;
+pub mod block_info;
+pub mod transaction_info;
+
+

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -3,6 +3,7 @@ use std::{
     time::Duration,
 };
 use std::cmp::min;
+use std::time::Instant;
 
 use anyhow::Context;
 use base64::Engine;
@@ -845,39 +846,44 @@ impl PostgresSession {
         }
 
         {
+            let started = Instant::now();
             let deleted_rows = self.client.execute(
                 &format!(
                     r"
                     DELETE FROM banking_stage_results_2.transactions WHERE transaction_id <= {transaction_id}
                 ", transaction_id = cutoff_transaction_incl
                 ), &[]).await.unwrap();
-            info!("Deleted {} rows from transactions", deleted_rows);
+            info!("Deleted {} rows from transactions in {:.2}ms", deleted_rows, started.elapsed().as_secs_f32());
         }
         {
+            let started = Instant::now();
             let deleted_rows = self.client.execute(
                 &format!(
                     r"
                     DELETE FROM banking_stage_results_2.accounts_map_transaction WHERE transaction_id <= {transaction_id}
                 ", transaction_id = cutoff_transaction_incl
                 ), &[]).await.unwrap();
-            info!("Deleted {} rows from accounts_map_transaction", deleted_rows);
+            info!("Deleted {} rows from accounts_map_transaction in {:.2}ms", deleted_rows, started.elapsed().as_secs_f32());
         }
         {
+            let started = Instant::now();
             let deleted_rows = self.client.execute(
                 &format!(
                     r"
                     DELETE FROM banking_stage_results_2.transaction_infos WHERE processed_slot < {cutoff_slot}
                 ", cutoff_slot = cutoff_slot_excl
                 ), &[]).await.unwrap();
-            info!("Deleted {} rows from transaction_infos", deleted_rows);
-        }{
+            info!("Deleted {} rows from transaction_infos in {:.2}ms", deleted_rows, started.elapsed().as_secs_f32());
+        }
+        {
+            let started = Instant::now();
             let deleted_rows = self.client.execute(
                 &format!(
                     r"
                     DELETE FROM banking_stage_results_2.transaction_slot WHERE slot < {cutoff_slot}
                 ", cutoff_slot = cutoff_slot_excl
                 ), &[]).await.unwrap();
-            info!("Deleted {} rows from transaction_slot", deleted_rows);
+            info!("Deleted {} rows from transaction_slot in {:.2}ms", deleted_rows, started.elapsed().as_secs_f32());
         }
 
         {

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -693,17 +693,17 @@ impl PostgresSession {
 
 impl PostgresSession {
     pub async fn cleanup_old_data(&self, dry_run: bool) {
+        // keep 1mio slots (apprx 4 days)
         let slots_to_keep = 1000000;
 
         // max slot from blocks table
         let latest_slot = self.client.query_one(
             "SELECT max(slot) as latest_slot FROM banking_stage_results_2.blocks", &[])
-        .await.unwrap();
+            .await.unwrap();
         // assume not null
         let latest_slot: i64 = latest_slot.get("latest_slot");
         info!("latest_slot={} from blocks table; keeping {} slots", latest_slot, slots_to_keep);
 
-        // keep 1mio slots (apprx 4 days)
         // do not delete cutoff_slot
         let cutoff_slot_excl = latest_slot - slots_to_keep;
 
@@ -711,9 +711,9 @@ impl PostgresSession {
             let cutoff_transaction_from_txi_incl = self.client.query_one(
                 &format!(
                     r"
-                    SELECT max(transaction_id) as transaction_id FROM banking_stage_results_2.transaction_infos
-                    WHERE processed_slot < {cutoff_slot}
-                ",
+                        SELECT max(transaction_id) as transaction_id FROM banking_stage_results_2.transaction_infos
+                        WHERE processed_slot < {cutoff_slot}
+                    ",
                     cutoff_slot = cutoff_slot_excl
                 ),
                 &[]).await.unwrap();
@@ -722,9 +722,9 @@ impl PostgresSession {
             let cutoff_transaction_from_txslot_incl = self.client.query_one(
                 &format!(
                     r"
-                    SELECT max(transaction_id) as transaction_id FROM banking_stage_results_2.transaction_slot
-                    WHERE slot < {cutoff_slot}
-                ",
+                        SELECT max(transaction_id) as transaction_id FROM banking_stage_results_2.transaction_slot
+                        WHERE slot < {cutoff_slot}
+                    ",
                     cutoff_slot = cutoff_slot_excl
                 ),
                 &[]).await.unwrap();
@@ -749,9 +749,9 @@ impl PostgresSession {
             let tx_to_delete = self.client.query_one(
                 &format!(
                     r"
-                    SELECT count(*) as cnt_tx FROM banking_stage_results_2.accounts_map_transaction amt
-                    WHERE amt.transaction_id <= {cutoff_transaction}
-                ",
+                        SELECT count(*) as cnt_tx FROM banking_stage_results_2.accounts_map_transaction amt
+                        WHERE amt.transaction_id <= {cutoff_transaction}
+                    ",
                     cutoff_transaction = cutoff_transaction_incl
                 ),
                 &[]).await.unwrap();
@@ -765,9 +765,9 @@ impl PostgresSession {
             let amb_to_delete = self.client.query_one(
                 &format!(
                     r"
-                    SELECT count(*) as cnt_ambs FROM banking_stage_results_2.accounts_map_blocks amb
-                    WHERE amb.slot <= {cutoff_slot}
-                ",
+                        SELECT count(*) as cnt_ambs FROM banking_stage_results_2.accounts_map_blocks amb
+                        WHERE amb.slot <= {cutoff_slot}
+                    ",
                     cutoff_slot = cutoff_slot_excl
                 ),
                 &[]).await.unwrap();
@@ -781,9 +781,9 @@ impl PostgresSession {
             let txi_to_delete = self.client.query_one(
                 &format!(
                     r"
-                    SELECT count(*) as cnt_txis FROM banking_stage_results_2.transaction_infos txi
-                    WHERE txi.processed_slot <= {cutoff_slot}
-                ",
+                        SELECT count(*) as cnt_txis FROM banking_stage_results_2.transaction_infos txi
+                        WHERE txi.processed_slot <= {cutoff_slot}
+                    ",
                     cutoff_slot = cutoff_slot_excl
                 ),
                 &[]).await.unwrap();
@@ -797,9 +797,9 @@ impl PostgresSession {
             let txslot_to_delete = self.client.query_one(
                 &format!(
                     r"
-                    SELECT count(*) as cnt_txslots FROM banking_stage_results_2.transaction_slot tx_slot
-                    WHERE tx_slot.slot <= {cutoff_slot}
-                ",
+                        SELECT count(*) as cnt_txslots FROM banking_stage_results_2.transaction_slot tx_slot
+                        WHERE tx_slot.slot <= {cutoff_slot}
+                    ",
                     cutoff_slot = cutoff_slot_excl
                 ),
                 &[]).await.unwrap();


### PR DESCRIPTION

### Usage

Configure PostgreSQL Database connection using `PG_CONFIG`:

> PG_CONFIG="host=localhost dbname=bankingstage2 user=bankingstage_sidecar password=secret sslmode=disable"

> Usage: cleanupdb [OPTIONS] --num-slots-to-keep <NUM_SLOTS_TO_KEEP>
  Options:
  -n, --num-slots-to-keep <NUM_SLOTS_TO_KEEP>
          num of slots to keep relative to highest slot in blocks table
  -d, --dry-run
          do not perform destructive operations



### Sample output
> 2023-12-21T13:33:42.186852Z  INFO grpc_banking_transactions_notifications::postgres: Connecting to Postgres    
2023-12-21T13:33:42.186832Z  INFO grpc_banking_transactions_notifications::postgres: Running cleanup job with slots_to_keep=35    
2023-12-21T13:33:42.190472Z  INFO grpc_banking_transactions_notifications::postgres: Configured work_mem=256MB    
2023-12-21T13:33:42.190482Z  INFO grpc_banking_transactions_notifications::postgres: Rows before cleanup:    
2023-12-21T13:33:42.197360Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <blocks>: 5650    
2023-12-21T13:33:42.230944Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <accounts>: 713639    
2023-12-21T13:33:42.233951Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <transactions>: 33322    
2023-12-21T13:33:42.361577Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <accounts_map_blocks>: 7423440    
2023-12-21T13:33:42.422185Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <accounts_map_transaction>: 426428    
2023-12-21T13:33:42.468309Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <transaction_infos>: 22171    
2023-12-21T13:33:42.469161Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <transaction_slot>: 0    
2023-12-21T13:33:42.469615Z  INFO grpc_banking_transactions_notifications::postgres: latest_slot=237126750 from blocks table; keeping 35 slots - i.e. slot 237126715    
2023-12-21T13:33:42.471728Z DEBUG grpc_banking_transactions_notifications::postgres: cutoff_transaction_from_txi_incl: Some(1927177)    
2023-12-21T13:33:42.471742Z DEBUG grpc_banking_transactions_notifications::postgres: cutoff_transaction_from_txslot_incl: None    
2023-12-21T13:33:42.471760Z  INFO grpc_banking_transactions_notifications::postgres: delete slots but keep slots including and after 237126715    
2023-12-21T13:33:42.471766Z  INFO grpc_banking_transactions_notifications::postgres: should delete transactions with id =< 1927177    
2023-12-21T13:33:42.485370Z  INFO grpc_banking_transactions_notifications::postgres: would delete transactions: 37740    
2023-12-21T13:33:42.603793Z  INFO grpc_banking_transactions_notifications::postgres: would delete from accounts_map_blocks: 7344936    
2023-12-21T13:33:42.647735Z  INFO grpc_banking_transactions_notifications::postgres: would delete from transaction_infos: 1697    
2023-12-21T13:33:42.649282Z  INFO grpc_banking_transactions_notifications::postgres: would delete from transaction_slot: 0    
2023-12-21T13:33:42.652058Z  INFO grpc_banking_transactions_notifications::postgres: Deleted 1851 rows from transactions in 0.00ms    
2023-12-21T13:33:42.666470Z  INFO grpc_banking_transactions_notifications::postgres: Deleted 37740 rows from accounts_map_transaction in 0.01ms    
2023-12-21T13:33:42.712132Z  INFO grpc_banking_transactions_notifications::postgres: Deleted 1697 rows from transaction_infos in 0.05ms    
2023-12-21T13:33:42.712593Z  INFO grpc_banking_transactions_notifications::postgres: Deleted 0 rows from transaction_slot in 0.00ms    
2023-12-21T13:33:42.712603Z  INFO grpc_banking_transactions_notifications::postgres: Rows after cleanup:    
2023-12-21T13:33:42.713340Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <blocks>: 5650    
2023-12-21T13:33:42.732269Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <accounts>: 713639    
2023-12-21T13:33:42.734507Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <transactions>: 31471    
2023-12-21T13:33:42.832309Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <accounts_map_blocks>: 7423440    
2023-12-21T13:33:42.899617Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <accounts_map_transaction>: 388688    
2023-12-21T13:33:42.946367Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <transaction_infos>: 20474    
2023-12-21T13:33:42.946754Z  INFO grpc_banking_transactions_notifications::postgres: - rows count in table <transaction_slot>: 0   