### PR TITLE
build amt_latest tx array with faster method

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -151,3 +151,20 @@ BEGIN
     RETURN  tmplist[(len + 1 - n_limit):];
 END
 $$ LANGUAGE plpgsql IMMUTABLE CALLED ON NULL INPUT;
+
+
+DROP FUNCTION array_dedup_append;
+
+-- select banking_stage_results_2.array_prepend_and_truncate('{8,3,2,1}', '{5,3}', 3); -- 5,3,8
+CREATE OR REPLACE FUNCTION banking_stage_results_2.array_prepend_and_truncate(base bigint[], append bigint[], n_limit int)
+    RETURNS bigint[]
+AS $$
+DECLARE
+    tmplist  bigint[];
+    len int;
+BEGIN
+    tmplist := append || base;
+    len := CARDINALITY(tmplist);
+    RETURN  tmplist[:n_limit];
+END
+$$ LANGUAGE plpgsql IMMUTABLE CALLED ON NULL INPUT;


### PR DESCRIPTION
use simple algo: append new transactions at beginning (left) in the array; truncate to 1100 (keeping some extra elements which might get removed if there are duplicates)