### PR TITLE
postgres schema fixes after moving to self-operated PostgreSQL

### DIFF
--- a/DBA.md
+++ b/DBA.md
@@ -1,0 +1,28 @@
+
+
+
+## Inspect page density and TOAST usage
+Shows how many rows fit on pages and how TOAST is used.
+
+The related tunings are:
+* configure `toast_tuple_target`
+* configure ```STORAGE PLAIN/MAIN/EXTENDED/EXTERNAL```
+* order of columns in the table
+
+```sql
+SELECT
+  pgsut.schemaname as schema_name,
+  pgsut.relname as table_name,
+  pg_size_pretty(pg_relation_size(pg_class.oid)) main_size,
+  pg_size_pretty(pg_relation_size(reltoastrelid)) toast_size,
+  n_live_tup,
+  pg_relation_size(pg_class.oid)/(n_live_tup+n_dead_tup) main_avg_size,
+  pg_relation_size(reltoastrelid)/(n_live_tup+n_dead_tup) toast_avg_size,
+  (select option_value::int FROM pg_options_to_table(reloptions) WHERE option_name='toast_tuple_target') as toast_tuple_target
+FROM pg_class
+INNER JOIN pg_namespace ns on relnamespace = ns.oid   
+INNER JOIN pg_stat_user_tables pgsut ON pgsut.relid=pg_class.oid
+WHERE (n_live_tup+n_dead_tup)>0
+AND nspname='banking_stage_results_2'
+ORDER BY 1,2
+```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ Data is retrieved via Solana RPC and Geysers gRPC API.
 
 ## Database Configuration
 ### Database Roles
-* `bankingstage_dashboard` - read-only access to the database for the dashboard web application
 * `bankingstage_sidecar` - write access to the database for the sidecar importer
+* `bankingstage_dashboard` - read-only access to the database for the dashboard web application
+* `query_user` - group for read-only access to the database intended for human user interaction with database
+
+```sql
+CREATE USER some_user_in_group_query_user PASSWORD 'test';
+GRANT query_user TO some_user_in_group_query_user;
+```
 
 ### Configure sidecar PostgreSQL connection
-export PG_CONFIG="host=localhost dbname=bankingstage user=bankingstage_dashboard password=test sslmode=disable"
+export PG_CONFIG="host=localhost dbname=the_banking_stage_db user=some_user_in_group_query_user password=test sslmode=disable"
 
 ### Database Schema
 The database schema is defined in the [migration.sql](migration.sql) file.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
-# TO INSTALL POSTGRES SCHEMA AND DATABASE
+# BankingStage Sidecar
+This is a sidecar application for the BankingStage project. It is responsible for importing data from the Solana blockchain into the PostgreSQL database.
+Data is retrieved via Solana RPC and Geysers gRPC API.
 
-sudo -u postgres psql postgres
-###### in postgres
-create data
-create database mangolana;
-grant all privileges on database mangolana to galactus;
+## Database Configuration
+### Database Roles
+* `bankingstage_dashboard` - read-only access to the database for the dashboard web application
+* `bankingstage_sidecar` - write access to the database for the sidecar importer
 
+### Configure sidecar PostgreSQL connection
+export PG_CONFIG="host=localhost dbname=bankingstage user=bankingstage_dashboard password=test sslmode=disable"
 
-psql -d mangolana < migration.sql
+### Database Schema
+The database schema is defined in the [migration.sql](migration.sql) file.
+For new database installations start with the [init-database.sql](init-database.sql) file.
+Required is a PostgreSQL database (tested version 15).
 
-export PG_CONFIG="host=localhost dbname=mangolana user=galactus password=test sslmode=disable" 
-
-### give rights to user
-
-GRANT ALL PRIVILEGES ON DATABASE mangolana TO galactus;
-GRANT ALL PRIVILEGES ON SCHEMA banking_stage_results TO galactus;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA banking_stage_results TO galactus;
-ALTER DEFAULT PRIVILEGES IN SCHEMA banking_stage_results GRANT ALL PRIVILEGES  ON TABLES TO galactus;

--- a/fly-hetzner-migration.toml
+++ b/fly-hetzner-migration.toml
@@ -1,4 +1,6 @@
-app = "solana-bankingstage-geyser-sidecar"
+
+
+app = "solana-bankingstage-geyser-sidecar-migrate-hetzner"
 primary_region = "fra"
 kill_signal = "SIGINT"
 kill_timeout = "5s"

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,5 @@
 app = "solana-bankingstage-geyser-sidecar"
+# shared-cpu-2x@4096MB
 primary_region = "fra"
 kill_signal = "SIGINT"
 kill_timeout = "5s"

--- a/init-database.sql
+++ b/init-database.sql
@@ -1,26 +1,27 @@
 -- setup new postgresql database; tested with PostgreSQL 15
 
--- CREATE DATABASE bankingstage3a
+-- CREATE DATABASE the_banking_stage_db
 -- run migration.sql
 
 -- setup sidecar user
-GRANT CONNECT ON DATABASE bankingstage3a TO bankingstage_sidecar;
+GRANT CONNECT ON DATABASE the_banking_stage_db TO bankingstage_sidecar;
 ALTER USER bankingstage_sidecar CONNECTION LIMIT 10;
 GRANT USAGE ON SCHEMA banking_stage_results_2 TO bankingstage_sidecar;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA banking_stage_results_2 TO bankingstage_sidecar;
 ALTER DEFAULT PRIVILEGES IN SCHEMA banking_stage_results_2 GRANT ALL PRIVILEGES ON TABLES TO bankingstage_sidecar;
 GRANT USAGE ON ALL SEQUENCES IN SCHEMA banking_stage_results_2 TO bankingstage_sidecar;
+ALTER DEFAULT PRIVILEGES IN SCHEMA banking_stage_results_2 GRANT USAGE ON SEQUENCES TO bankingstage_sidecar;
 
 
 -- setup query_user
-GRANT CONNECT ON DATABASE bankingstage3a TO query_user;
+GRANT CONNECT ON DATABASE the_banking_stage_db TO query_user;
 ALTER USER query_user CONNECTION LIMIT 5;
 GRANT USAGE ON SCHEMA banking_stage_results_2 TO query_user;
 GRANT SELECT ON ALL TABLES in SCHEMA banking_stage_results_2 TO query_user;
 
 
 -- setup bankingstage_dashboard
-GRANT CONNECT ON DATABASE bankingstage3a TO bankingstage_dashboard;
+GRANT CONNECT ON DATABASE the_banking_stage_db TO bankingstage_dashboard;
 ALTER USER bankingstage_sidecar CONNECTION LIMIT 10;
 GRANT USAGE ON SCHEMA banking_stage_results_2 TO bankingstage_dashboard;
 GRANT SELECT ON ALL TABLES in SCHEMA banking_stage_results_2 TO bankingstage_dashboard;

--- a/init-database.sql
+++ b/init-database.sql
@@ -1,0 +1,26 @@
+-- setup new postgresql database; tested with PostgreSQL 15
+
+-- CREATE DATABASE bankingstage3a
+-- run migration.sql
+
+-- setup sidecar user
+GRANT CONNECT ON DATABASE bankingstage3a TO bankingstage_sidecar;
+ALTER USER bankingstage_sidecar CONNECTION LIMIT 10;
+GRANT USAGE ON SCHEMA banking_stage_results_2 TO bankingstage_sidecar;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA banking_stage_results_2 TO bankingstage_sidecar;
+ALTER DEFAULT PRIVILEGES IN SCHEMA banking_stage_results_2 GRANT ALL PRIVILEGES ON TABLES TO bankingstage_sidecar;
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA banking_stage_results_2 TO bankingstage_sidecar;
+
+
+-- setup query_user
+GRANT CONNECT ON DATABASE bankingstage3a TO query_user;
+ALTER USER query_user CONNECTION LIMIT 5;
+GRANT USAGE ON SCHEMA banking_stage_results_2 TO query_user;
+GRANT SELECT ON ALL TABLES in SCHEMA banking_stage_results_2 TO query_user;
+
+
+-- setup bankingstage_dashboard
+GRANT CONNECT ON DATABASE bankingstage3a TO bankingstage_dashboard;
+ALTER USER bankingstage_sidecar CONNECTION LIMIT 10;
+GRANT USAGE ON SCHEMA banking_stage_results_2 TO bankingstage_dashboard;
+GRANT SELECT ON ALL TABLES in SCHEMA banking_stage_results_2 TO bankingstage_dashboard;

--- a/migration.sql
+++ b/migration.sql
@@ -148,3 +148,50 @@ BEGIN
     RETURN  tmplist[(len + 1 - n_limit):];
 END
 $$ LANGUAGE plpgsql IMMUTABLE CALLED ON NULL INPUT;
+
+
+ALTER TABLE banking_stage_results_2.accounts
+    SET (
+        autovacuum_vacuum_scale_factor=0,
+        autovacuum_vacuum_threshold=100,
+        autovacuum_vacuum_insert_scale_factor=0,
+        autovacuum_vacuum_insert_threshold=100,
+        autovacuum_analyze_scale_factor=0,
+        autovacuum_analyze_threshold=100
+        );
+
+ALTER TABLE banking_stage_results_2.transactions
+    SET (
+        autovacuum_vacuum_scale_factor=0,
+        autovacuum_vacuum_threshold=1000,
+        autovacuum_vacuum_insert_scale_factor=0,
+        autovacuum_vacuum_insert_threshold=1000,
+        autovacuum_analyze_scale_factor=0,
+        autovacuum_analyze_threshold=1000
+        );
+
+ALTER TABLE banking_stage_results_2.accounts_map_transaction
+    SET (
+        autovacuum_vacuum_scale_factor=0,
+        autovacuum_vacuum_threshold=10000,
+        autovacuum_vacuum_insert_scale_factor=0,
+        autovacuum_vacuum_insert_threshold=10000,
+        autovacuum_analyze_scale_factor=0,
+        autovacuum_analyze_threshold=10000
+    );
+
+ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest
+    SET (
+        autovacuum_vacuum_scale_factor=0,
+        autovacuum_vacuum_threshold=100,
+        autovacuum_vacuum_insert_scale_factor=0,
+        autovacuum_vacuum_insert_threshold=100,
+        autovacuum_analyze_scale_factor=0,
+        autovacuum_analyze_threshold=100
+        );
+
+ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest ALTER COLUMN tx_ids SET STORAGE main;
+
+ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest SET (FILLFACTOR=90);
+ALTER INDEX banking_stage_results_2.accounts_map_transaction_latest_pkey SET (FILLFACTOR=50);
+

--- a/migration.sql
+++ b/migration.sql
@@ -7,6 +7,8 @@ CREATE TABLE banking_stage_results_2.transactions(
   signature varchar(88) NOT NULL,
   UNIQUE(signature)
 );
+-- page layout: rows are small and must store in main
+ALTER TABLE banking_stage_results_2.transactions SET (toast_tuple_threshold=2000);
 
 CREATE TABLE banking_stage_results_2.transaction_infos (
   transaction_id BIGINT PRIMARY KEY,
@@ -17,11 +19,13 @@ CREATE TABLE banking_stage_results_2.transaction_infos (
   prioritization_fees BIGINT NOT NULL,
   supp_infos text
 );
+ALTER TABLE banking_stage_results_2.transaction_infos SET (toast_tuple_threshold=2000);
 
 CREATE TABLE banking_stage_results_2.errors (
   error_code int primary key,
   error_text text
 );
+ALTER TABLE banking_stage_results_2.errors SET (toast_tuple_threshold=2000);
 
 CREATE TABLE banking_stage_results_2.transaction_slot (
   transaction_id BIGINT,
@@ -31,6 +35,7 @@ CREATE TABLE banking_stage_results_2.transaction_slot (
   utc_timestamp TIMESTAMP NOT NULL,
   PRIMARY KEY (transaction_id, slot, error_code)
 );
+ALTER TABLE banking_stage_results_2.transaction_slot SET (toast_tuple_threshold=2000);
 
 
 CREATE INDEX idx_transaction_slot_timestamp ON banking_stage_results_2.transaction_slot(utc_timestamp);
@@ -46,12 +51,14 @@ CREATE TABLE banking_stage_results_2.blocks (
   total_cu_requested BIGINT NOT NULL,
   supp_infos text
 );
+ALTER TABLE banking_stage_results_2.blocks SET (toast_tuple_threshold=2000);
 
 CREATE TABLE banking_stage_results_2.accounts(
 	acc_id bigserial PRIMARY KEY,
 	account_key varchar(44) NOT NULL,
 	UNIQUE (account_key)
 );
+ALTER TABLE banking_stage_results_2.accounts SET (toast_tuple_threshold=2000);
 
 CREATE TABLE banking_stage_results_2.accounts_map_transaction(
   transaction_id BIGINT NOT NULL,
@@ -61,6 +68,7 @@ CREATE TABLE banking_stage_results_2.accounts_map_transaction(
   is_atl BOOL NOT NULL,
   PRIMARY KEY (transaction_id, acc_id)
 );
+ALTER TABLE banking_stage_results_2.accounts_map_transaction SET (toast_tuple_threshold=2000);
 
 CREATE INDEX idx_blocks_block_hash ON banking_stage_results_2.blocks(block_hash);
 
@@ -74,6 +82,7 @@ CREATE TABLE banking_stage_results_2.accounts_map_blocks (
   supp_infos text,
   PRIMARY KEY (acc_id, slot, is_write_locked)
 );
+ALTER TABLE banking_stage_results_2.accounts_map_blocks SET (toast_tuple_threshold=2000);
 CREATE INDEX idx_accounts_map_blocks_slot ON banking_stage_results_2.accounts_map_blocks(slot);
 
 insert into banking_stage_results_2.errors (error_text, error_code) VALUES 
@@ -119,6 +128,7 @@ CREATE TABLE banking_stage_results_2.accounts_map_transaction_latest(
     -- sorted: oldest to latest, max 1000
     tx_ids BIGINT[]
 );
+ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest SET (toast_tuple_threshold=2000)
 
 CREATE OR REPLACE FUNCTION array_dedup_append(base bigint[], append bigint[], n_limit int)
     RETURNS bigint[]

--- a/migration.sql
+++ b/migration.sql
@@ -1,9 +1,9 @@
 CREATE SCHEMA banking_stage_results_2;
 
 CREATE TABLE banking_stage_results_2.transactions(
-  signature char(88) primary key,
-  transaction_id bigserial,
-  UNIQUE(transaction_id)
+  transaction_id bigserial PRIMARY KEY,
+  signature varchar(88) NOT NULL,
+  UNIQUE(signature)
 );
 
 CREATE TABLE banking_stage_results_2.transaction_infos (
@@ -46,8 +46,8 @@ CREATE TABLE banking_stage_results_2.blocks (
 );
 
 CREATE TABLE banking_stage_results_2.accounts(
-	acc_id bigserial primary key,
-	account_key char(44),
+	acc_id bigserial PRIMARY KEY,
+	account_key varchar(44) NOT NULL,
 	UNIQUE (account_key)
 );
 

--- a/migration.sql
+++ b/migration.sql
@@ -1,6 +1,6 @@
 
 -- for initial database setup start with init-database.sql
-
+CREATE SCHEMA banking_stage_results_2;
 
 CREATE TABLE banking_stage_results_2.transactions(
                                                      transaction_id bigserial PRIMARY KEY,

--- a/migration.sql
+++ b/migration.sql
@@ -60,9 +60,6 @@ CREATE TABLE banking_stage_results_2.accounts_map_transaction(
   PRIMARY KEY (transaction_id, acc_id)
 );
 
-CREATE INDEX accounts_map_transaction_acc_id ON banking_stage_results_2.accounts_map_transaction(acc_id);
-CREATE INDEX accounts_map_transaction_transaction_id ON banking_stage_results_2.accounts_map_transaction(transaction_id);
-
 CREATE INDEX idx_blocks_block_hash ON banking_stage_results_2.blocks(block_hash);
 
 CREATE TABLE banking_stage_results_2.accounts_map_blocks (

--- a/migration.sql
+++ b/migration.sql
@@ -55,8 +55,8 @@ CREATE TABLE banking_stage_results_2.blocks (
                                                 leader_identity varchar(44) NOT NULL,
                                                 supp_infos text
 );
--- page layout: blockhash is important
-ALTER TABLE banking_stage_results_2.blocks SET (toast_tuple_target=128);
+-- page layout: blockhash is frequently used
+ALTER TABLE banking_stage_results_2.blocks SET (toast_tuple_target=200);
 CREATE INDEX idx_blocks_block_hash ON banking_stage_results_2.blocks(block_hash);
 
 

--- a/migration.sql
+++ b/migration.sql
@@ -8,11 +8,11 @@ CREATE TABLE banking_stage_results_2.transactions(
 
 CREATE TABLE banking_stage_results_2.transaction_infos (
   transaction_id BIGINT PRIMARY KEY,
-  processed_slot BIGINT,
-  is_successful BOOL,
-  cu_requested BIGINT,
-  cu_consumed BIGINT,
-  prioritization_fees BIGINT,
+  processed_slot BIGINT NOT NULL,
+  is_successful BOOL NOT NULL,
+  cu_requested BIGINT NOT NULL,
+  cu_consumed BIGINT NOT NULL,
+  prioritization_fees BIGINT NOT NULL,
   supp_infos text
 );
 
@@ -24,8 +24,8 @@ CREATE TABLE banking_stage_results_2.errors (
 CREATE TABLE banking_stage_results_2.transaction_slot (
   transaction_id BIGINT,
   slot BIGINT,
-  error_code INT,
-  count INT,
+  error_code INT NOT NULL,
+  count INT NOT NULL,
   utc_timestamp TIMESTAMP NOT NULL,
   PRIMARY KEY (transaction_id, slot, error_code)
 );
@@ -36,12 +36,12 @@ CREATE INDEX idx_transaction_slot_slot ON banking_stage_results_2.transaction_sl
 
 CREATE TABLE banking_stage_results_2.blocks (
   slot BIGINT PRIMARY KEY,
-  block_hash char(44),
-  leader_identity char(44),
-  successful_transactions BIGINT,
-  processed_transactions BIGINT,
-  total_cu_used BIGINT,
-  total_cu_requested BIGINT,
+  block_hash varchar(44),
+  leader_identity varchar(44) NOT NULL,
+  successful_transactions BIGINT NOT NULL,
+  processed_transactions BIGINT NOT NULL,
+  total_cu_used BIGINT NOT NULL,
+  total_cu_requested BIGINT NOT NULL,
   supp_infos text
 );
 
@@ -52,23 +52,23 @@ CREATE TABLE banking_stage_results_2.accounts(
 );
 
 CREATE TABLE banking_stage_results_2.accounts_map_transaction(
-  acc_id BIGINT,
-  transaction_id BIGINT,
-  is_writable BOOL,
-  is_signer BOOL,
-  is_atl BOOL,
+  transaction_id BIGINT NOT NULL,
+  acc_id BIGINT NOT NULL,
+  is_writable BOOL NOT NULL,
+  is_signer BOOL NOT NULL,
+  is_atl BOOL NOT NULL,
   PRIMARY KEY (transaction_id, acc_id)
 );
 
 CREATE INDEX idx_blocks_block_hash ON banking_stage_results_2.blocks(block_hash);
 
 CREATE TABLE banking_stage_results_2.accounts_map_blocks (
-  acc_id BIGINT,
-  slot BIGINT,
-  is_write_locked BOOL,
-  total_cu_consumed BIGINT,
-  total_cu_requested BIGINT,
-  prioritization_fees_info text,
+  acc_id BIGINT NOT NULL,
+  slot BIGINT NOT NULL,
+  is_write_locked BOOL NOT NULL,
+  total_cu_consumed BIGINT NOT NULL,
+  total_cu_requested BIGINT NOT NULL,
+  prioritization_fees_info text NOT NULL,
   supp_infos text,
   PRIMARY KEY (acc_id, slot, is_write_locked)
 );

--- a/migration.sql
+++ b/migration.sql
@@ -1,142 +1,159 @@
+
 -- for initial database setup start with init-database.sql
 
-CREATE SCHEMA banking_stage_results_2;
 
 CREATE TABLE banking_stage_results_2.transactions(
-  transaction_id bigserial PRIMARY KEY,
-  signature varchar(88) NOT NULL,
-  UNIQUE(signature)
+                                                     transaction_id bigserial PRIMARY KEY,
+                                                     signature varchar(88) STORAGE main NOT NULL,
+                                                     UNIQUE(signature)
 );
--- page layout: rows are small and must store in main
-ALTER TABLE banking_stage_results_2.transactions SET (toast_tuple_threshold=2000);
+-- page layout: rows are small and must store in main; compression is okey
+-- ALTER TABLE banking_stage_results_2.transactions SET (toast_tuple_target=4080);
+
 
 CREATE TABLE banking_stage_results_2.transaction_infos (
-  transaction_id BIGINT PRIMARY KEY,
-  processed_slot BIGINT NOT NULL,
-  is_successful BOOL NOT NULL,
-  cu_requested BIGINT NOT NULL,
-  cu_consumed BIGINT NOT NULL,
-  prioritization_fees BIGINT NOT NULL,
-  supp_infos text
+                                                           transaction_id BIGINT PRIMARY KEY,
+                                                           processed_slot BIGINT NOT NULL,
+                                                           is_successful BOOL NOT NULL,
+                                                           cu_requested BIGINT NOT NULL,
+                                                           cu_consumed BIGINT NOT NULL,
+                                                           prioritization_fees BIGINT NOT NULL,
+                                                           supp_infos text STORAGE extended
 );
-ALTER TABLE banking_stage_results_2.transaction_infos SET (toast_tuple_threshold=2000);
+-- page layout: move supp_infos to toast; everything else should stay on main
+ALTER TABLE banking_stage_results_2.transaction_infos SET (toast_tuple_target=128);
+
 
 CREATE TABLE banking_stage_results_2.errors (
-  error_code int primary key,
-  error_text text
+                                                error_code int primary key,
+                                                error_text text STORAGE main NOT NULL
 );
-ALTER TABLE banking_stage_results_2.errors SET (toast_tuple_threshold=2000);
+-- page layout: keep everything on main
+
 
 CREATE TABLE banking_stage_results_2.transaction_slot (
-  transaction_id BIGINT,
-  slot BIGINT,
-  error_code INT NOT NULL,
-  count INT NOT NULL,
-  utc_timestamp TIMESTAMP NOT NULL,
-  PRIMARY KEY (transaction_id, slot, error_code)
+                                                          transaction_id BIGINT,
+                                                          slot BIGINT NOT NULL,
+                                                          error_code INT NOT NULL,
+                                                          count INT NOT NULL,
+                                                          utc_timestamp TIMESTAMP NOT NULL,
+                                                          PRIMARY KEY (transaction_id, slot, error_code)
 );
-ALTER TABLE banking_stage_results_2.transaction_slot SET (toast_tuple_threshold=2000);
-
-
+-- page layout: keep everything on main (note: TIMESTAMP uses storage plain)
+ALTER TABLE banking_stage_results_2.transaction_slot SET (toast_tuple_target=128);
 CREATE INDEX idx_transaction_slot_timestamp ON banking_stage_results_2.transaction_slot(utc_timestamp);
 CREATE INDEX idx_transaction_slot_slot ON banking_stage_results_2.transaction_slot(slot);
 
+
 CREATE TABLE banking_stage_results_2.blocks (
-  slot BIGINT PRIMARY KEY,
-  block_hash varchar(44),
-  leader_identity varchar(44) NOT NULL,
-  successful_transactions BIGINT NOT NULL,
-  processed_transactions BIGINT NOT NULL,
-  total_cu_used BIGINT NOT NULL,
-  total_cu_requested BIGINT NOT NULL,
-  supp_infos text
+                                                slot BIGINT PRIMARY KEY,
+                                                successful_transactions BIGINT NOT NULL,
+                                                processed_transactions BIGINT NOT NULL,
+                                                total_cu_used BIGINT NOT NULL,
+                                                total_cu_requested BIGINT NOT NULL,
+                                                block_hash varchar(44) STORAGE main NOT NULL,
+                                                leader_identity varchar(44) NOT NULL,
+                                                supp_infos text
 );
-ALTER TABLE banking_stage_results_2.blocks SET (toast_tuple_threshold=2000);
-
-CREATE TABLE banking_stage_results_2.accounts(
-	acc_id bigserial PRIMARY KEY,
-	account_key varchar(44) NOT NULL,
-	UNIQUE (account_key)
-);
-ALTER TABLE banking_stage_results_2.accounts SET (toast_tuple_threshold=2000);
-
-CREATE TABLE banking_stage_results_2.accounts_map_transaction(
-  transaction_id BIGINT NOT NULL,
-  acc_id BIGINT NOT NULL,
-  is_writable BOOL NOT NULL,
-  is_signer BOOL NOT NULL,
-  is_atl BOOL NOT NULL,
-  PRIMARY KEY (transaction_id, acc_id)
-);
-ALTER TABLE banking_stage_results_2.accounts_map_transaction SET (toast_tuple_threshold=2000);
-
+-- page layout: blockhash is important
+ALTER TABLE banking_stage_results_2.blocks SET (toast_tuple_target=128);
 CREATE INDEX idx_blocks_block_hash ON banking_stage_results_2.blocks(block_hash);
 
-CREATE TABLE banking_stage_results_2.accounts_map_blocks (
-  acc_id BIGINT NOT NULL,
-  slot BIGINT NOT NULL,
-  is_write_locked BOOL NOT NULL,
-  total_cu_consumed BIGINT NOT NULL,
-  total_cu_requested BIGINT NOT NULL,
-  prioritization_fees_info text NOT NULL,
-  supp_infos text,
-  PRIMARY KEY (acc_id, slot, is_write_locked)
+
+CREATE TABLE banking_stage_results_2.accounts(
+                                                 acc_id bigserial PRIMARY KEY,
+                                                 account_key varchar(44) STORAGE main NOT NULL,
+                                                 UNIQUE (account_key)
 );
-ALTER TABLE banking_stage_results_2.accounts_map_blocks SET (toast_tuple_threshold=2000);
+-- page layout: rows are small and must store in main; compression is okey
+-- ALTER TABLE banking_stage_results_2.transactions SET (toast_tuple_target=4080);
+
+
+CREATE TABLE banking_stage_results_2.accounts_map_transaction(
+                                                                 transaction_id BIGINT NOT NULL,
+                                                                 acc_id BIGINT NOT NULL,
+                                                                 is_writable BOOL NOT NULL,
+                                                                 is_signer BOOL NOT NULL,
+                                                                 is_atl BOOL NOT NULL,
+                                                                 PRIMARY KEY (transaction_id, acc_id)
+);
+-- page layout: very small rows, keep everything on main
+ALTER TABLE banking_stage_results_2.accounts_map_transaction SET (toast_tuple_target=128);
+
+
+CREATE TABLE banking_stage_results_2.accounts_map_blocks (
+                                                             acc_id BIGINT NOT NULL,
+                                                             slot BIGINT NOT NULL,
+                                                             is_write_locked BOOL NOT NULL,
+                                                             total_cu_consumed BIGINT NOT NULL,
+                                                             total_cu_requested BIGINT NOT NULL,
+                                                             prioritization_fees_info text STORAGE extended NOT NULL,
+                                                             supp_infos text STORAGE extended,
+                                                             PRIMARY KEY (acc_id, slot, is_write_locked)
+);
+-- page layout: move prioritization_fees_info and supp_infos to toast; everything else should stay on main
+ALTER TABLE banking_stage_results_2.accounts_map_blocks SET (toast_tuple_target=128);
 CREATE INDEX idx_accounts_map_blocks_slot ON banking_stage_results_2.accounts_map_blocks(slot);
 
-insert into banking_stage_results_2.errors (error_text, error_code) VALUES 
-        ('AccountBorrowOutstanding', 0),
-        ('AccountInUse', 1),
-        ('AccountLoadedTwice', 2),
-        ('AccountNotFound', 3),
-        ('AddressLookupTableNotFound', 4),
-        ('AlreadyProcessed', 5),
-        ('BlockhashNotFound', 6),
-        ('CallChainTooDeep', 7),
-        ('ClusterMaintenance', 8),
-        ('DuplicateInstruction', 9),
-        ('InstructionError', 10),
-        ('InsufficientFundsForFee', 11),
-        ('InsufficientFundsForRent', 12),
-        ('InvalidAccountForFee', 13),
-        ('InvalidAccountIndex', 14),
-        ('InvalidAddressLookupTableData', 15),
-        ('InvalidAddressLookupTableIndex', 16),
-        ('InvalidAddressLookupTableOwner', 17),
-        ('InvalidLoadedAccountsDataSizeLimit', 18),
-        ('InvalidProgramForExecution', 19),
-        ('InvalidRentPayingAccount', 20),
-        ('InvalidWritableAccount', 21),
-        ('MaxLoadedAccountsDataSizeExceeded', 22),
-        ('MissingSignatureForFee', 23),
-        ('ProgramAccountNotFound', 24),
-        ('ResanitizationNeeded', 25),
-        ('SanitizeFailure', 26),
-        ('SignatureFailure', 27),
-        ('TooManyAccountLocks', 28),
-        ('UnbalancedTransaction', 29),
-        ('UnsupportedVersion', 30),
-        ('WouldExceedAccountDataBlockLimit', 31),
-        ('WouldExceedAccountDataTotalLimit', 32),
-        ('WouldExceedMaxAccountCostLimit', 33),
-        ('WouldExceedMaxBlockCostLimit', 34),
-        ('WouldExceedMaxVoteCostLimit', 35);
 
 CREATE TABLE banking_stage_results_2.accounts_map_transaction_latest(
-    acc_id BIGINT PRIMARY KEY,
-    -- sorted: oldest to latest, max 1000
-    tx_ids BIGINT[]
+                                                                        acc_id BIGINT PRIMARY KEY,
+    -- max 120 int8 ids (see LIMIT_LATEST_TXS_PER_ACCOUNT)
+                                                                        tx_ids BIGINT[] STORAGE main NOT NULL
 );
-ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest SET (toast_tuple_threshold=2000)
+-- page layout: tx_ids is the only relevant data must remain in main; tx_ids size is intentionally limited to fit a single page; compression is okey
+-- do not limit tuple size, it is not relevant
+ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest SET (toast_tuple_target=4080);
+
+
+
+
+INSERT INTO banking_stage_results_2.errors (error_text, error_code) VALUES
+                                                                        ('AccountBorrowOutstanding', 0),
+                                                                        ('AccountInUse', 1),
+                                                                        ('AccountLoadedTwice', 2),
+                                                                        ('AccountNotFound', 3),
+                                                                        ('AddressLookupTableNotFound', 4),
+                                                                        ('AlreadyProcessed', 5),
+                                                                        ('BlockhashNotFound', 6),
+                                                                        ('CallChainTooDeep', 7),
+                                                                        ('ClusterMaintenance', 8),
+                                                                        ('DuplicateInstruction', 9),
+                                                                        ('InstructionError', 10),
+                                                                        ('InsufficientFundsForFee', 11),
+                                                                        ('InsufficientFundsForRent', 12),
+                                                                        ('InvalidAccountForFee', 13),
+                                                                        ('InvalidAccountIndex', 14),
+                                                                        ('InvalidAddressLookupTableData', 15),
+                                                                        ('InvalidAddressLookupTableIndex', 16),
+                                                                        ('InvalidAddressLookupTableOwner', 17),
+                                                                        ('InvalidLoadedAccountsDataSizeLimit', 18),
+                                                                        ('InvalidProgramForExecution', 19),
+                                                                        ('InvalidRentPayingAccount', 20),
+                                                                        ('InvalidWritableAccount', 21),
+                                                                        ('MaxLoadedAccountsDataSizeExceeded', 22),
+                                                                        ('MissingSignatureForFee', 23),
+                                                                        ('ProgramAccountNotFound', 24),
+                                                                        ('ResanitizationNeeded', 25),
+                                                                        ('SanitizeFailure', 26),
+                                                                        ('SignatureFailure', 27),
+                                                                        ('TooManyAccountLocks', 28),
+                                                                        ('UnbalancedTransaction', 29),
+                                                                        ('UnsupportedVersion', 30),
+                                                                        ('WouldExceedAccountDataBlockLimit', 31),
+                                                                        ('WouldExceedAccountDataTotalLimit', 32),
+                                                                        ('WouldExceedMaxAccountCostLimit', 33),
+                                                                        ('WouldExceedMaxBlockCostLimit', 34),
+                                                                        ('WouldExceedMaxVoteCostLimit', 35);
+
 
 CREATE OR REPLACE FUNCTION array_dedup_append(base bigint[], append bigint[], n_limit int)
     RETURNS bigint[]
 AS $$
 DECLARE
-	tmplist  bigint[];
-	el		bigint;
-	len int;
+    tmplist  bigint[];
+    el		bigint;
+    len int;
 BEGIN
     tmplist := base;
     FOREACH el IN ARRAY append LOOP
@@ -178,7 +195,7 @@ ALTER TABLE banking_stage_results_2.accounts_map_transaction
         autovacuum_vacuum_insert_threshold=10000,
         autovacuum_analyze_scale_factor=0,
         autovacuum_analyze_threshold=10000
-    );
+        );
 
 ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest
     SET (
@@ -189,8 +206,6 @@ ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest
         autovacuum_analyze_scale_factor=0,
         autovacuum_analyze_threshold=100
         );
-
-ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest ALTER COLUMN tx_ids SET STORAGE main;
 
 ALTER TABLE banking_stage_results_2.accounts_map_transaction_latest SET (FILLFACTOR=90);
 ALTER INDEX banking_stage_results_2.accounts_map_transaction_latest_pkey SET (FILLFACTOR=50);

--- a/migration.sql
+++ b/migration.sql
@@ -1,3 +1,5 @@
+-- for initial database setup start with init-database.sql
+
 CREATE SCHEMA banking_stage_results_2;
 
 CREATE TABLE banking_stage_results_2.transactions(
@@ -111,18 +113,6 @@ insert into banking_stage_results_2.errors (error_text, error_code) VALUES
         ('WouldExceedMaxAccountCostLimit', 33),
         ('WouldExceedMaxBlockCostLimit', 34),
         ('WouldExceedMaxVoteCostLimit', 35);
-
-CLUSTER banking_stage_results_2.blocks using blocks_pkey;
-VACUUM FULL banking_stage_results_2.blocks;
--- optional
-CLUSTER banking_stage_results_2.transaction_slot using idx_transaction_slot_timestamp;
-VACUUM FULL banking_stage_results_2.transaction_slot;
-
-CLUSTER banking_stage_results_2.accounts_map_transaction using accounts_map_transaction_pkey;
-
-CLUSTER banking_stage_results_2.transactions using transactions_pkey;
-
-CLUSTER banking_stage_results_2.accounts using accounts_pkey;
 
 CREATE TABLE banking_stage_results_2.accounts_map_transaction_latest(
     acc_id BIGINT PRIMARY KEY,

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -777,12 +777,12 @@ impl PostgresSession {
         let statement = r#"
             INSERT INTO banking_stage_results_2.blocks (
                 slot,
-                block_hash,
-                leader_identity,
                 successful_transactions,
                 processed_transactions,
                 total_cu_used,
                 total_cu_requested,
+                block_hash,
+                leader_identity,
                 supp_infos
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT DO NOTHING
@@ -794,12 +794,12 @@ impl PostgresSession {
                 statement,
                 &[
                     &block_info.slot,
-                    &block_info.block_hash,
-                    &block_info.leader_identity.clone().unwrap_or_default(),
                     &block_info.successful_transactions,
                     &block_info.processed_transactions,
                     &block_info.total_cu_used,
                     &block_info.total_cu_requested,
+                    &block_info.block_hash,
+                    &block_info.leader_identity.clone().unwrap_or_default(),
                     &serde_json::to_string(&block_info.sup_info)?,
                 ],
             )

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -200,7 +200,7 @@ impl PostgresSession {
                 format!(
                     r#"
         CREATE TEMP TABLE {}(
-            signature varchar(88)
+            signature varchar(88) NOT NULL
         );
         "#,
                     temp_table
@@ -262,7 +262,7 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            key TEXT
+            key TEXT NOT NULL
         );",
                     temp_table
                 )
@@ -322,11 +322,11 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            sig varchar(88),
-            slot BIGINT,
-            error_code INT,
-            count INT,
-            utc_timestamp TIMESTAMP
+            sig varchar(88) NOT NULL,
+            slot BIGINT NOT NULL,
+            error_code INT NOT NULL,
+            count INT NOT NULL,
+            utc_timestamp TIMESTAMP NOT NULL
         );",
                     temp_table
                 )
@@ -414,11 +414,11 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            account_key varchar(44),
-            signature varchar(88),
-            is_writable BOOL,
-            is_signer BOOL,
-            is_atl BOOL
+            account_key varchar(44) NOT NULL,
+            signature varchar(88) NOT NULL,
+            is_writable BOOL NOT NULL,
+            is_signer BOOL NOT NULL,
+            is_atl BOOL NOT NULL
         );",
                     temp_table
                 )
@@ -551,12 +551,12 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            signature varchar(88),
-            processed_slot BIGINT,
-            is_successful BOOL,
-            cu_requested BIGINT,
-            cu_consumed BIGINT,
-            prioritization_fees BIGINT,
+            signature varchar(88) NOT NULL,
+            processed_slot BIGINT NOT NULL,
+            is_successful BOOL  NOT NULL,
+            cu_requested BIGINT NOT NULL,
+            cu_consumed BIGINT NOT NULL,
+            prioritization_fees BIGINT NOT NULL,
             supp_infos text
         )",
                     temp_table
@@ -648,11 +648,11 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            account_key varchar(44),
-            slot BIGINT,
-            is_write_locked BOOL,
-            total_cu_requested BIGINT,
-            total_cu_consumed BIGINT,
+            account_key varchar(44) NOT NULL,
+            slot BIGINT NOT NULL,
+            is_write_locked BOOL NOT NULL,
+            total_cu_requested BIGINT NOT NULL,
+            total_cu_consumed BIGINT NOT NULL,
             prioritization_fees_info text
         )",
                     temp_table

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -200,7 +200,7 @@ impl PostgresSession {
                 format!(
                     r#"
         CREATE TEMP TABLE {}(
-            signature char(88)
+            signature varchar(88)
         );
         "#,
                     temp_table
@@ -322,7 +322,7 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            sig char(88),
+            sig varchar(88),
             slot BIGINT,
             error_code INT,
             count INT,
@@ -414,8 +414,8 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            account_key char(44),
-            signature char(88),
+            account_key varchar(44),
+            signature varchar(88),
             is_writable BOOL,
             is_signer BOOL,
             is_atl BOOL
@@ -551,7 +551,7 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            signature char(88),
+            signature varchar(88),
             processed_slot BIGINT,
             is_successful BOOL,
             cu_requested BIGINT,
@@ -648,7 +648,7 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            account_key char(44),
+            account_key varchar(44),
             slot BIGINT,
             is_write_locked BOOL,
             total_cu_requested BIGINT,

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -235,7 +235,7 @@ impl PostgresSession {
         let statement = format!(
             r#"
         INSERT INTO banking_stage_results_2.transactions(signature) SELECT signature from {}
-        ON CONFLICT DO NOTHING
+        ON CONFLICT(signature) DO NOTHING
         "#,
             temp_table
         );
@@ -296,7 +296,7 @@ impl PostgresSession {
         let statement = format!(
             r#"
         INSERT INTO banking_stage_results_2.accounts(account_key) SELECT key from {}
-        ON CONFLICT DO NOTHING
+        ON CONFLICT(account_key) DO NOTHING
         "#,
             temp_table
         );

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -515,7 +515,7 @@ impl PostgresSession {
         let started_at = Instant::now();
         let num_rows = self.client.execute(statement.as_str(), &[]).await?;
         debug!(
-            "merged new transactions into accounts_map_transaction_latest for {} accounts in {}ms",
+            "merged new transactions into accounts_map_transaction_latest temp table for {} accounts in {}ms",
             num_rows,
             started_at.elapsed().as_millis()
         );

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -262,7 +262,7 @@ impl PostgresSession {
             .execute(
                 format!(
                     "CREATE TEMP TABLE {}(
-            key TEXT NOT NULL
+            account_key VARCHAR(44) NOT NULL
         );",
                     temp_table
                 )
@@ -274,7 +274,7 @@ impl PostgresSession {
         let statement = format!(
             r#"
             COPY {}(
-                key
+                account_key
             ) FROM STDIN BINARY
         "#,
             temp_table
@@ -295,7 +295,7 @@ impl PostgresSession {
 
         let statement = format!(
             r#"
-        INSERT INTO banking_stage_results_2.accounts(account_key) SELECT key from {}
+        INSERT INTO banking_stage_results_2.accounts(account_key) SELECT account_key from {}
         ON CONFLICT(account_key) DO NOTHING
         "#,
             temp_table


### PR DESCRIPTION
* note: went for varchar(44/88) which is controversal
* reorder columns to put the fixed sized ones first
* fly config is temporary and must be removed after migration

new Postgres connection url (without ssl):
> PG_CONFIG="postgres://bankingstage_sidecar:the_secret@mango-hetzner-01._peer.internal:5432/banking_stage?sslmode=disable&connect_timeout=60&keepalives=1&keepalives_idle=30"
